### PR TITLE
Small corrections during testing

### DIFF
--- a/app.py
+++ b/app.py
@@ -362,7 +362,7 @@ def main():
     elif args.command == "verify":
         catalog = load_catalog(args.catalog)
         print(f"Loaded catalog with {len(catalog)} environment variables")
-        if args.definition:
+        if hasattr(args, "definition") and args.definition:
             # if this is not a file then likely we are trying to pull from aws
             use_aws = not os.path.isfile(args.definition)
             env_checker = get_task_definition_checker(args.definition, use_aws)

--- a/app.py
+++ b/app.py
@@ -205,7 +205,7 @@ def check_env_vars(
     def maybe_print(txt: str):
         if structured_output:
             return
-        print(str)
+        print(txt)
 
     # Load existing catalog if it exists
     if not os.path.exists(output_file):


### PR DESCRIPTION
Found a couple of issues while testing the tool:

 - Adding the hasattr() solved the issue in the verify command when you don't need to check any task definition (like the example in the readme file)
 ``` bash
 envhero verify -c whole_repo_env_var_catalog.json -t base_tasks --definition ""
usage: main.py [-h] {create,update,check,verify,tags_from_env} ...
main.py: error: unrecognized arguments: --definition
```

 - Line 208, from str to txt to solve:
 ```bash
<class 'str'>
<class 'str'>
<class 'str'>
<class 'str'>
```